### PR TITLE
Create StreamWish.ts

### DIFF
--- a/src/extractor/StreamWish.ts
+++ b/src/extractor/StreamWish.ts
@@ -2,6 +2,7 @@ import { Context, Format, Meta, UrlResult } from '../types';
 import { buildMediaFlowProxyExtractorStreamUrl } from '../utils';
 import { Extractor } from './Extractor';
 
+/** @see https://github.com/Gujal00/ResolveURL/blob/master/script.module.resolveurl/lib/resolveurl/plugins/streamwish.py */
 export class StreamWish extends Extractor {
   public readonly id = 'StreamWish';
   public readonly label = 'StreamWish(MFP)';


### PR DESCRIPTION
The streamwish is using fake png headers on their ts segments so we need mediaflow for this extractor. I already pr my finding to the mediaflow author and he is now merging both the fake steip bytes and also streamwish support for this extractor.

p.s this eztractor uses dynamic domin redirections so better leave the logic of domains intact if you dont want to spend your time lol.