### PR TITLE
Create TurboVidPlay.ts

### DIFF
--- a/src/extractor/TurboVidPlay.ts
+++ b/src/extractor/TurboVidPlay.ts
@@ -57,7 +57,7 @@ export class TurboVidPlay extends Extractor {
     );
 
     const groups = match?.groups as Record<string, string> | undefined;
-    const mediaUrl = groups?.url;
+    const mediaUrl = groups?.['url'];
 
     if (!mediaUrl) {
       throw new NotFoundError('Video link not found');


### PR DESCRIPTION
This extractor in a lot of cases uses fake PNG bytes in every ts segment header but also it uses normal links that are directly playable and no need for mediflow.

The code supports both cases where it check the link if contains /data/ it playes directly if not it send it to mediaflow for more decoding.

I already pr the extractor code support on mediaflow and the author merge it.