### PR TITLE
Update FileMoon.ts

### DIFF
--- a/src/extractor/FileMoon.ts
+++ b/src/extractor/FileMoon.ts
@@ -42,10 +42,7 @@ export class FileMoon extends Extractor {
   }
 
   public override normalize(url: URL): URL {
-    if (url.pathname.startsWith('/d/')) {
-      return new URL(url.href.replace('/d/', '/e/'));
-    }
-    return url;
+    return new URL(url.href.replace('/e/', '/d/'));
   }
 
   protected async extractInternal(ctx: Context, url: URL, meta: Meta, originalUrl?: URL): Promise<UrlResult[]> {
@@ -60,9 +57,10 @@ export class FileMoon extends Extractor {
     const $ = cheerio.load(html);
     const title = $('h3').text().trim();
 
-    const iframeUrlMatch = html.match(/iframe.*?src=["'](.*?)["']/);
-    if (iframeUrlMatch && iframeUrlMatch[1]) {
-      return await this.extractInternal(ctx, new URL(iframeUrlMatch[1]), { title, ...meta }, url);
+    const iframeUrlMatches = Array.from(html.matchAll(/iframe.*?src=["'](.*?)["']/g));
+    if (iframeUrlMatches.length) {
+      // Use last match because there can be fake adblock catcher urls before
+      return await this.extractInternal(ctx, new URL((iframeUrlMatches[iframeUrlMatches.length - 1] as RegExpExecArray)[1] as string), { title, ...meta }, url);
     }
 
     const playlistUrl = await buildMediaFlowProxyExtractorStreamUrl(ctx, this.fetcher, 'FileMoon', originalUrl as URL, headers);


### PR DESCRIPTION
To fix /d/ type of links which at the moment it failed to do so

Case
`https://filemoon.link/d/yuc8ymtgv0wb/1`

Also a PR should be opened with the changes because the mediaflow part code is failing too

https://github.com/mhdzumair/mediaflow-proxy/pull/188