### PR TITLE
fix: build sqlite3 from source to resolve glibc crash on ARM64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,15 @@ FROM node:24 AS builder
 WORKDIR /app
 
 COPY package*.json ./
+# you might want to add --build-from-source=sqlite3 here too.
 RUN npm ci
 
 COPY tsconfig.json ./
 COPY src ./src
 RUN npm run build
 
-RUN npm ci --only=production
+# FIX: Force sqlite3 to compile against the container's glibc 
+RUN npm ci --only=production --build-from-source=sqlite3
 
 FROM node:24
 WORKDIR /app


### PR DESCRIPTION
Hey. 

I was trying to spin up the latest Docker image on an ARM64 setup today and ran into a crash loop on startup (`ERR_DLOPEN_FAILED` / `GLIBC_2.38 not found`). 

It looks like `npm` is grabbing a prebuilt `sqlite3` binary that requires a newer version of `glibc` than what is currently shipped inside the `node:24` base image. 

To fix it, I just added the `--build-from-source=sqlite3` flag to the `npm ci` command in the `Dockerfile`. This forces the container to compile the database bindings natively against its own `glibc` version during the build, which completely stops the crash.

