### PR TITLE
fix glibc compatibility by updating runner image to node:24-trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24 AS builder
+FROM node:24-trixie AS builder
 WORKDIR /app
 
 COPY package*.json ./


### PR DESCRIPTION
`node:24-trixie` is based on Debian 13 and provides a newer glibc version (>= 2.38), 
which is required by some native dependencies.

no functional changes besides the base image upgrade.

if you gonna renovate bot auto update deps it's gonna need a newer image as a runner